### PR TITLE
Remove mixin retina-sprite's $dimensions parameter

### DIFF
--- a/src/retina/_sprite.scss
+++ b/src/retina/_sprite.scss
@@ -31,7 +31,7 @@ $retina-sprite-urls2x    : 0;
  * @param {Boolean} [$hover=false]
  * @param {Boolean} [$active=false]
  */
-@mixin retina-sprite($name, $sprite-name: 0, $dimensions: false, $hover: false, $active: false) {
+@mixin retina-sprite($name, $sprite-name: 0, $hover: false, $active: false) {
   $index: 2;
   $len: length($retina-sprite-names);
 
@@ -47,7 +47,7 @@ $retina-sprite-urls2x    : 0;
   $sprite2x     : nth($retina-sprite-sprites2x, $index);
   $sprite-url2x : nth($retina-sprite-urls2x, $index);
 
-  @include _retina-sprite($name, $sprite, $sprite-url, $sprite2x, $sprite-url2x, $hover, $active, $dimensions);
+  @include _retina-sprite($name, $sprite, $sprite-url, $sprite2x, $sprite-url2x, $hover, $active);
 }
 
 @function retina-sprite-width($name, $sprite-name: 0) {


### PR DESCRIPTION
At commit 21c5888 a new parameter, $dimensions, was introduced in the central mixin: retina-sprite. Adding $dimensions before the $hover and $active parameters breaks all existing mixin calls which followed the old mixin signature. That change also broke cross-compatibility with @AdamBrodzinski's version, as all clients would need to change all their usages of the retina-sprite mixin if they had already specified arguments for $hover and $active. Moreover, the added parameter was undocumented and caused the demo to fail. If we want to introduce the new parameter, it should be added to the documentation, it's default value should be true, and it should be added as the last parameter to maintain backward compatibility.
